### PR TITLE
Make compile tasks `@Cacheable`

### DIFF
--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtCompile.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtCompile.java
@@ -20,11 +20,13 @@ import java.util.concurrent.Callable;
 
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.OutputDirectory;
 
 /**
  * Task to run the GWT compiler for production quality output.
  */
+@CacheableTask
 public class GwtCompile extends AbstractGwtCompile {
 
 	/** {@inheritDoc} */

--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtDraftCompile.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtDraftCompile.java
@@ -17,11 +17,13 @@ package org.wisepersist.gradle.plugins.gwt;
 
 import java.io.File;
 
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.OutputDirectory;
 
 /**
  * Task to run the GWT compiler for development quality output.
  */
+@CacheableTask
 public class GwtDraftCompile extends AbstractGwtCompile {
 	public GwtDraftCompile() {
 		setDraftCompile(true);


### PR DESCRIPTION
Support the gradle build cache for the compile tasks. Other tasks may be candidates for this as well. See also https://blog.gradle.org/introducing-gradle-build-cache.