### PR TITLE
Add support filtering JsInterop types for export with whitelist (i.e.…

### DIFF
--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
@@ -38,7 +38,7 @@ import org.gradle.plugins.ide.idea.IdeaPlugin;
 
 public class GwtBasePlugin implements Plugin<Project> {
 	public static final String GWT_TASK_GROUP = "GWT";
-	
+
 	public static final String GWT_CONFIGURATION = "gwt";
 	public static final String GWT_SDK_CONFIGURATION = "gwtSdk";
 	public static final String EXTENSION_NAME = "gwt";
@@ -48,18 +48,18 @@ public class GwtBasePlugin implements Plugin<Project> {
 	public static final String GEN_DIR = "gen";
 	public static final String CACHE_DIR = "cache";
 	public static final String LOG_DIR = "log";
-	
+
 	public static final String DEV_WAR = "war";
-	
+
 	public static final String TASK_GWT_SUPER_DEV = "gwtSuperDev";
-	
+
 	public static final String GWT_GROUP = "com.google.gwt";
 	public static final String GWT_DEV = "gwt-dev";
 	public static final String GWT_USER = "gwt-user";
 	public static final String GWT_CODESERVER = "gwt-codeserver";
 	public static final String GWT_ELEMENTAL = "gwt-elemental";
 	public static final String GWT_SERVLET = "gwt-servlet";
-	
+
 	private static final Logger logger = Logging.getLogger(GwtBasePlugin.class);
 	private Project project;
 	private GwtPluginExtension extension;
@@ -71,28 +71,28 @@ public class GwtBasePlugin implements Plugin<Project> {
 	public void apply(final Project project) {
 		this.project = project;
 		project.getPlugins().apply(JavaPlugin.class);
-		
+
 		final File gwtBuildDir = new File(project.getBuildDir(), BUILD_DIR);
-		
+
 		extension = configureGwtExtension(gwtBuildDir);
-		
+
 		configureAbstractActionTasks();
 		configureAbstractTasks();
 		configureGwtCompile();
 		configureGwtDev();
 		configureGwtSuperDev();
-		
+
 		gwtConfiguration = project.getConfigurations().create(GWT_CONFIGURATION)
 				.setDescription("Classpath for GWT client libraries that are not included in the war");
 		gwtSdkConfiguration = project.getConfigurations().create(GWT_SDK_CONFIGURATION)
 				.setDescription("Classpath for GWT SDK libraries (gwt-dev, gwt-user)");
 		allGwtConfigurations = project.files(gwtConfiguration, gwtSdkConfiguration);
-		
+
 		addToMainSourceSetClasspath(allGwtConfigurations);
-		
+
 		final SourceSet testSourceSet = getTestSourceSet();
 		testSourceSet.setCompileClasspath(testSourceSet.getCompileClasspath().plus(allGwtConfigurations));
-		
+
 		project.afterEvaluate(new Action<Project>() {
 			@Override
 			public void execute(final Project project) {
@@ -103,15 +103,15 @@ public class GwtBasePlugin implements Plugin<Project> {
 						getMainSourceSet().getAllJava().getSrcDirs().toArray())
 						.plus(project.files(testSourceSet.getAllJava()
 								.getSrcDirs().toArray())).plus(runtimeClasspath);
-					
+
 					configureTestTasks(extension);
 				}
 				testSourceSet.setRuntimeClasspath(runtimeClasspath);
-				
+
 				boolean versionSet = false;
 				int major = 2;
 				int minor = 5;
-				
+
 				final String gwtVersion = extension.getGwtVersion();
 				if(gwtVersion != null && !extension.getGwtVersion().isEmpty()) {
 					final String[] token = gwtVersion.split("\\.");
@@ -127,18 +127,18 @@ public class GwtBasePlugin implements Plugin<Project> {
 						logger.warn("GWT version "+extension.getGwtVersion()+" can not be parsed. Valid versions must have the format major.minor.patch where major and minor are positive integer numbers.");
 					}
 				}
-				
+
 				if ((major == 2 && minor >= 5) || major > 2) {
 					if(extension.isCodeserver()) {
 						createSuperDevModeTask(project);
 					}
 				}
-				
+
 				if(versionSet) {
 					project.getDependencies().add(GWT_SDK_CONFIGURATION, gwtDependency(GWT_DEV, gwtVersion));
 					project.getDependencies().add(GWT_SDK_CONFIGURATION, gwtDependency(GWT_USER, gwtVersion));
 					project.getDependencies().add(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, gwtDependency(GWT_SERVLET, gwtVersion));
-					
+
 					if ((major == 2 && minor >= 5) || major > 2) {
 						if(extension.isCodeserver()) {
 							project.getDependencies().add(GWT_CONFIGURATION, gwtDependency(GWT_CODESERVER, gwtVersion));
@@ -150,7 +150,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 						logger.warn("GWT version is <2.5 -> additional dependencies are not added.");
 					}
 				}
-				
+
 			}});
 
 		project.getPlugins().withType(EclipsePlugin.class,
@@ -169,13 +169,13 @@ public class GwtBasePlugin implements Plugin<Project> {
 					}
 				});
 	}
-	
+
 	private String gwtDependency(final String artifactId, final String gwtVersion) {
 		return GWT_GROUP+":"+artifactId+":"+gwtVersion;
 	}
 
 	private GwtPluginExtension configureGwtExtension(final File buildDir) {
-		
+
 		final GwtPluginExtension extension = project.getExtensions().create(EXTENSION_NAME, GwtPluginExtension.class);
 		extension.setDevWar(project.file(DEV_WAR));
 		extension.setExtraDir(new File(buildDir, EXTRA_DIR));
@@ -186,7 +186,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 		extension.getCompiler().setLocalWorkers(Runtime.getRuntime().availableProcessors());
 		extension.setLogLevel(getLogLevel());
 		extension.getSuperDev().setUseClasspathForSrc(true);
-		
+
 		ConventionMapping conventionMapping = ((IConventionAware)extension).getConventionMapping();
 		conventionMapping.map("src", new Callable<FileCollection>(){
 			@Override
@@ -194,7 +194,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 				final SourceSet mainSourceSet = getMainSourceSet();
 				return project.files(mainSourceSet.getAllJava().getSrcDirs()).plus(project.files(mainSourceSet.getOutput().getResourcesDir()));
 			}});
-		
+
 		return extension;
 	}
 
@@ -240,7 +240,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 					}});
 			}});
 	}
-	
+
 	private void configureAbstractActionTasks() {
 		final JavaPluginConvention javaConvention = getJavaConvention();
 		final SourceSet mainSourceSet = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
@@ -248,7 +248,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 			@Override
 			public void execute(final AbstractGwtActionTask task) {
 				task.setGroup(GwtBasePlugin.GWT_TASK_GROUP);
-				
+
 				ConventionMapping conventionMapping = ((IConventionAware)task).getConventionMapping();
 				conventionMapping.map("modules", new Callable<List<String>>() {
 					@Override
@@ -302,11 +302,11 @@ public class GwtBasePlugin implements Plugin<Project> {
 						return extension.getJsInteropMode();
 					}
 				});
-				conventionMapping.map("generateJsInteropExports", extension::getGenerateJsInteropExports);
+				conventionMapping.map("jsInteropExports", extension::getJsInteropExports);
 				conventionMapping.map("methodNameDisplayMode", extension::getMethodNameDisplayMode);
 			}});
 	}
-	
+
 	private void configureGwtCompile() {
 		project.getTasks().withType(AbstractGwtCompile.class, new Action<AbstractGwtCompile>() {
 			@Override
@@ -326,7 +326,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 			}
 		});
 	}
-	
+
 	private void configureGwtSuperDev() {
 		project.getTasks().withType(GwtSuperDev.class, new Action<GwtSuperDev>() {
 			@Override
@@ -342,23 +342,23 @@ public class GwtBasePlugin implements Plugin<Project> {
 			}
 		});
 	}
-	
+
 	private void configureTestTasks(final GwtPluginExtension gwtPluginExtension) {
 		project.getTasks().withType(Test.class, new Action<Test>() {
 			@Override
 			public void execute(final Test testTask) {
 				testTask.getTestLogging().setShowStandardStreams(true);
-				
+
 				final GwtTestExtension testExtension = testTask.getExtensions().create("gwt", GwtTestExtension.class);
 				testExtension.configure(gwtPluginExtension, (IConventionAware) testExtension);
-				
+
 				project.afterEvaluate(new Action<Project>() {
 					@Override
 					public void execute(Project t) {
 						String gwtArgs = testExtension.getParameterString();
 						testTask.systemProperty("gwt.args", gwtArgs);
 						logger.info("Using gwt.args for test: "+ gwtArgs);
-						
+
 						if (testExtension.getCacheDir() != null) {
 							testTask.systemProperty("gwt.persistentunitcachedir", testExtension.getCacheDir());
 							testExtension.getCacheDir().mkdirs();
@@ -366,7 +366,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 						}
 					}
 				});
-				
+
 				project.getPlugins().withType(GwtWarPlugin.class, new Action<GwtWarPlugin>() {
 					@Override
 					public void execute(GwtWarPlugin t) {
@@ -375,7 +375,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 			}
 		});
 	}
-	
+
 	private LogLevel getLogLevel() {
 		if(logger.isTraceEnabled()) {
 			return LogLevel.TRACE;
@@ -389,11 +389,11 @@ public class GwtBasePlugin implements Plugin<Project> {
 		// QUIET or ERROR
 		return LogLevel.ERROR;
 	}
-	
+
 	private SourceSet getMainSourceSet() {
 		return getJavaConvention().getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 	}
-	
+
 	private SourceSet getTestSourceSet() {
 		return getJavaConvention().getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME);
 	}
@@ -401,24 +401,24 @@ public class GwtBasePlugin implements Plugin<Project> {
 	private JavaPluginConvention getJavaConvention() {
 		return project.getConvention().getPlugin(JavaPluginConvention.class);
 	}
-	
+
 	private void addToMainSourceSetClasspath(FileCollection fileCollection) {
 		final SourceSet mainSourceSet = getMainSourceSet();
 		mainSourceSet.setCompileClasspath(getMainSourceSet().getCompileClasspath().plus(fileCollection));
 	}
-	
+
 	GwtPluginExtension getExtension() {
 		return extension;
 	}
-	
+
 	Configuration getGwtConfiguration() {
 		return gwtConfiguration;
 	}
-	
+
 	Configuration getGwtSdkConfiguration() {
 		return gwtSdkConfiguration;
 	}
-	
+
 	ConfigurableFileCollection getAllGwtConfigurations() {
 		return allGwtConfigurations;
 	}

--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtJsInteropExportsOptions.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtJsInteropExportsOptions.java
@@ -1,0 +1,42 @@
+package org.wisepersist.gradle.plugins.gwt;
+
+import java.util.List;
+
+/**
+ * Defines the options known by the {@link AbstractGwtActionTask} task.
+ */
+public interface GwtJsInteropExportsOptions {
+
+	boolean shouldGenerate();
+
+	/**
+	 * Sets the "-generateJsInteropExport" flag that enables the generation of JsInterop exports, disabled by default.
+	 *
+	 * @param shouldGenerate {@code true} if the "-generateJsInteropExport" flag should be set, {@code false} otherwise to set "-nogenerateJsInteropExports" flag
+	 *
+	 * @since <a href="http://www.gwtproject.org/release-notes.html#Release_Notes_2_8_0">GWT 2.8.0</a>
+	 */
+	void setGenerate(final boolean shouldGenerate);
+
+	List<String> getIncludePatterns();
+
+	/**
+	 * Sets the members and classes to include while generating JsInterop exports. Has only effect if {@linkplain #shouldGenerate() exporting} is enabled.
+	 *
+	 * @param includePatterns the members and classes to include - adds multiple "-includeJsInteropExports com.foo.*" flags
+	 *
+	 * @since <a href="http://www.gwtproject.org/release-notes.html#Release_Notes_2_8_1">GWT 2.8.1</a>
+	 */
+	void setIncludePatterns(final String... includePatterns);
+
+	List<String> getExcludePatterns();
+
+	/**
+	 * Sets the members and classes to exclude while generating JsInterop exports. Has only effect if {@linkplain #shouldGenerate() exporting} is enabled and {@linkplain #getIncludePatterns()} is not empty.
+	 *
+	 * @param excludePatterns the members and classes to exclude - adds multiple "-excludeJsInteropExports com.foo.internal.*" flags
+	 *
+	 * @since <a href="http://www.gwtproject.org/release-notes.html#Release_Notes_2_8_1">GWT 2.8.1</a>
+	 */
+	void setExcludePatterns(final String... excludePatterns);
+}

--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtPluginExtension.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtPluginExtension.java
@@ -27,6 +27,7 @@ import org.gradle.util.ConfigureUtil;
 
 import org.wisepersist.gradle.plugins.gwt.internal.GwtCompileOptionsImpl;
 import org.wisepersist.gradle.plugins.gwt.internal.GwtDevOptionsImpl;
+import org.wisepersist.gradle.plugins.gwt.internal.GwtJsInteropExportsOptionsImpl;
 import org.wisepersist.gradle.plugins.gwt.internal.GwtSuperDevOptionsImpl;
 
 public class GwtPluginExtension {
@@ -47,12 +48,12 @@ public class GwtPluginExtension {
 
 	private Boolean incremental;
 	private JsInteropMode jsInteropMode;
-	private Boolean generateJsInteropExports;
 	private MethodNameDisplayMode methodNameDisplayMode;
-	
+
 	private String minHeapSize = "256M";
 	private String maxHeapSize = "256M";
-	
+
+	private final GwtJsInteropExportsOptions jsInteropExports = new GwtJsInteropExportsOptionsImpl();
 	private final GwtDevOptions dev = new GwtDevOptionsImpl();
 	private final GwtSuperDevOptions superDev = new GwtSuperDevOptionsImpl();
 	private final GwtCompileOptions compiler = new GwtCompileOptionsImpl();
@@ -66,7 +67,7 @@ public class GwtPluginExtension {
 		this.modules.clear();
 		this.modules.addAll(modules);
 	}
-	
+
 	public void modules(String... modules) {
 		this.modules.addAll(Arrays.asList(modules));
 	}
@@ -78,19 +79,19 @@ public class GwtPluginExtension {
 	public void setGwtVersion(String gwtVersion) {
 		this.gwtVersion = gwtVersion;
 	}
-	
+
 	public boolean isCodeserver() {
 		return codeserver;
 	}
-	
+
 	public void setCodeserver(boolean codeserver) {
 		this.codeserver = codeserver;
 	}
-	
+
 	public boolean isElemental() {
 		return elemental;
 	}
-	
+
 	public void setElemental(boolean elemental) {
 		this.elemental = elemental;
 	}
@@ -103,7 +104,7 @@ public class GwtPluginExtension {
 		this.devModules.clear();
 		this.devModules.addAll(devModules);
 	}
-	
+
 	public void devModules(String... modules) {
 		this.devModules.addAll(Arrays.asList(modules));
 	}
@@ -171,34 +172,43 @@ public class GwtPluginExtension {
 	public void setMaxHeapSize(String maxHeapSize) {
 		this.maxHeapSize = maxHeapSize;
 	}
-	
+
+	public GwtJsInteropExportsOptions getJsInteropExports() {
+		return jsInteropExports;
+	}
+
+	public GwtPluginExtension jsInteropExports(Closure<GwtJsInteropExportsOptions> c) {
+		ConfigureUtil.configure(c, jsInteropExports);
+		return this;
+	}
+
 	public GwtDevOptions getDev() {
 		return dev;
 	}
-	
+
 	public GwtPluginExtension dev(Closure<GwtDevOptions> c) {
 		ConfigureUtil.configure(c, dev);
 		return this;
 	}
-	
+
 	public GwtSuperDevOptions getSuperDev() {
 		return superDev;
 	}
-	
+
 	public GwtPluginExtension superDev(Closure<GwtSuperDevOptions> c) {
 		ConfigureUtil.configure(c, superDev);
 		return this;
 	}
-	
+
 	public GwtCompileOptions getCompiler() {
 		return compiler;
 	}
-	
+
 	public GwtPluginExtension compiler(Closure<GwtCompileOptions> c) {
 		ConfigureUtil.configure(c, compiler);
 		return this;
 	}
-	
+
 	public GwtTestOptions getTest() {
 		return test;
 	}
@@ -215,27 +225,27 @@ public class GwtPluginExtension {
 	public void setSrc(FileCollection src) {
 		this.src = src;
 	}
-	
+
 	public String getSourceLevel() {
 		return sourceLevel;
 	}
-	
+
 	public void setSourceLevel(String sourceLevel) {
 		this.sourceLevel = sourceLevel;
 	}
-	
+
 	public Boolean getIncremental() {
 		return incremental;
 	}
-	
+
 	public void setIncremental(Boolean incremental) {
 		this.incremental = incremental;
 	}
-	
+
 	public JsInteropMode getJsInteropMode() {
 		return jsInteropMode;
 	}
-	
+
 	public void setJsInteropMode(JsInteropMode jsInteropMode) {
 		this.jsInteropMode = jsInteropMode;
 	}
@@ -248,28 +258,13 @@ public class GwtPluginExtension {
 		this.modulePathPrefix = modulePathPrefix;
 	}
 
-	public Boolean getGenerateJsInteropExports() {
-		return generateJsInteropExports;
-	}
-
-	/**
-	 * If set to true, this adds the parameter -generateJsInteropExports.
-	 * If set to false, this adds the parameter -nogenerateJsInteropExports.
-	 * Added in GWT 2.8.
-	 *
-	 * @param generateJsInteropExports Whether it generates JsInteropExports.
-	 */
-	public void setGenerateJsInteropExports(Boolean generateJsInteropExports) {
-		this.generateJsInteropExports = generateJsInteropExports;
-	}
-	
 	public MethodNameDisplayMode getMethodNameDisplayMode() {
 		return methodNameDisplayMode;
 	}
-	
+
 	/**
 	 * If set, this causes the "-XmethodNameDisplayMode" (added in GWT 2.7/2.8) parameter to be added.
-	 * 
+	 *
 	 * @param methodNameDisplayMode The method name display mode.
 	 */
 	public void setMethodNameDisplayMode(MethodNameDisplayMode methodNameDisplayMode) {

--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtJsInteropExportsOptionsImpl.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtJsInteropExportsOptionsImpl.java
@@ -1,0 +1,65 @@
+package org.wisepersist.gradle.plugins.gwt.internal;
+
+import static java.util.Arrays.stream;
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.wisepersist.gradle.plugins.gwt.GwtJsInteropExportsOptions;
+
+public class GwtJsInteropExportsOptionsImpl implements GwtJsInteropExportsOptions {
+
+	private boolean shouldGenerate;
+
+	private List<String> includePatterns;
+
+	private List<String> excludePatterns;
+
+	public GwtJsInteropExportsOptionsImpl() {
+		this.shouldGenerate = false;
+		this.includePatterns = new ArrayList<>();
+		this.excludePatterns = new ArrayList<>();
+	}
+
+	@Override
+	public boolean shouldGenerate() {
+		return shouldGenerate;
+	}
+
+	@Override
+	public void setGenerate(final boolean shouldGenerate) {
+		this.shouldGenerate = shouldGenerate;
+	}
+
+	@Override
+	public List<String> getIncludePatterns() {
+		return unmodifiableList(includePatterns);
+	}
+
+	@Override
+	public void setIncludePatterns(final String... includePatterns) {
+		this.includePatterns = toStream(includePatterns)
+				.filter(Objects::nonNull)
+				.collect(toList());
+	}
+
+	@Override
+	public List<String> getExcludePatterns() {
+		return unmodifiableList(excludePatterns);
+	}
+
+	@Override
+	public void setExcludePatterns(final String... excludePatterns) {
+		this.excludePatterns = toStream(excludePatterns)
+				.filter(Objects::nonNull)
+				.collect(toList());
+	}
+
+	private static Stream<String> toStream(final String... patterns) {
+		return (patterns != null) ? stream(patterns) : Stream.empty();
+	}
+}


### PR DESCRIPTION
... with whitelist (i.e. -includeJsInteropExport) / blacklist (i.e. -excludeJsInteropExports) and wildcards - see http://www.gwtproject.org/release-notes.html#Release_Notes_2_8_1