### PR TITLE
Use @Classpath instead of @Input for classpath

### DIFF
--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtActionTask.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtActionTask.java
@@ -26,6 +26,7 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
@@ -245,7 +246,7 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
 		this.src = src;
 	}
 
-	@Input
+	@Classpath
 	public FileCollection getClasspath() {
 		return classpath;
 	}


### PR DESCRIPTION
Using a remote build cache currently does not work properly.
This is caused by `classpath` being annotated with `@Input`.
After switching to `@Classpath` it also works for remote build caches (see https://docs.gradle.org/current/userguide/more_about_tasks.html for details about the annotations mentioned).
