### PR TITLE
#28: "Make jvmArgs accessible (Lombok in a linked module)""

### DIFF
--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtCompile.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtCompile.java
@@ -186,4 +186,9 @@ public class GwtCompile extends AbstractGwtCompile {
 		});
 		conventionMapping.map("closureFormattedOutput", options::getClosureFormattedOutput);
 	}
+
+	@Override
+	public void jvmArgs(Object... args) {
+		super.jvmArgs(args);
+	}
 }

--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtDraftCompile.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtDraftCompile.java
@@ -35,4 +35,9 @@ public class GwtDraftCompile extends AbstractGwtCompile {
 	public File getWar() {
 		return super.getWar();
 	}
+
+	@Override
+	public void jvmArgs(Object... args) {
+		super.jvmArgs(args);
+	}
 }


### PR DESCRIPTION
At this moment I am only pushing the changes in the plugin Java code.
The modified/working version of war-using-library with Lombok [can be seen in my repo](https://github.com/jaromor/gwt-gradle-plugin/commit/9dda647cfa96a27bddaf7b5773d35dae351a36d0). I hesitate to push that to jiakuan/gwt-gradle-plugin, the reason being I am pretty sure my gradle configuration, while working for me, is NOT the cleanest and/or most efficient approach.