### PR TITLE
Gradle 6+: use runtimeOnly configuration instead of runtimeElements for declaring dependencies

### DIFF
--- a/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/gwt-gradle-plugin/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
@@ -124,7 +124,7 @@ public class GwtBasePlugin implements Plugin<Project> {
 				if (parsedGwtVersion != null) {
 					project.getDependencies().add(GWT_SDK_CONFIGURATION, gwtDependency(GWT_DEV, parsedGwtVersion));
 					project.getDependencies().add(GWT_SDK_CONFIGURATION, gwtDependency(GWT_USER, parsedGwtVersion));
-					project.getDependencies().add(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, gwtDependency(GWT_SERVLET, parsedGwtVersion));
+					project.getDependencies().add(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, gwtDependency(GWT_SERVLET, parsedGwtVersion));
 
 					if ((major == 2 && minor >= 5) || major > 2) {
 						if(extension.isCodeserver()) {


### PR DESCRIPTION
Adding dependencies to the `runtimeElements` configuration is deprecated in Gradle 6. It's only meant for querying the dependencies by consumers. Using the plugin with Gradle 6 shows:

> **The runtimeElements configuration has been deprecated for dependency declaration.**
> This will fail with an error in Gradle 7.0. Please use the implementation or compileOnly or runtimeOnly configuration instead.

I think the dependency should be added to the `runtimeOnly` configuration instead. but please correct me if I'm wrong.