### PR TITLE
Fix outputs of the compileGwt task

### DIFF
--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtTask.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtTask.java
@@ -16,6 +16,7 @@
 package org.wisepersist.gradle.plugins.gwt;
 
 import java.io.File;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 
@@ -94,7 +95,7 @@ public abstract class AbstractGwtTask extends AbstractGwtActionTask {
     this.extra = extra;
   }
 
-  @OutputDirectory
+  @Internal
   public File getWorkDir() {
     return workDir;
   }
@@ -122,7 +123,7 @@ public abstract class AbstractGwtTask extends AbstractGwtActionTask {
     this.gen = gen;
   }
 
-  @OutputDirectory
+  @Internal
   public File getCacheDir() {
     return cacheDir;
   }

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtTask.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtTask.java
@@ -81,6 +81,7 @@ public abstract class AbstractGwtTask extends AbstractGwtActionTask {
     this.deploy = deploy;
   }
 
+  @Optional
   @OutputDirectory
   public File getExtra() {
     return extra;
@@ -109,6 +110,7 @@ public abstract class AbstractGwtTask extends AbstractGwtActionTask {
     this.workDir = workDir;
   }
 
+  @Optional
   @OutputDirectory
   public File getGen() {
     return gen;

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
@@ -45,9 +45,7 @@ public class GwtBasePlugin implements Plugin<Project> {
   public static final String GWT_SDK_CONFIGURATION = "gwtSdk";
   public static final String EXTENSION_NAME = "gwt";
   public static final String BUILD_DIR = "gwt";
-  public static final String EXTRA_DIR = "extra";
   public static final String WORK_DIR = "work";
-  public static final String GEN_DIR = "gen";
   public static final String CACHE_DIR = "cache";
   public static final String LOG_DIR = "log";
 
@@ -175,9 +173,7 @@ public class GwtBasePlugin implements Plugin<Project> {
     final GwtPluginExtension extension = project.getExtensions()
         .create(EXTENSION_NAME, GwtPluginExtension.class);
     extension.setDevWar(project.file(DEV_WAR));
-    extension.setExtraDir(new File(buildDir, EXTRA_DIR));
     extension.setWorkDir(new File(buildDir, WORK_DIR));
-    extension.setGenDir(new File(buildDir, GEN_DIR));
     extension.setCacheDir(new File(buildDir, CACHE_DIR));
     extension.getDev().setLogDir(new File(buildDir, LOG_DIR));
     extension.getCompiler()

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtSuperDev.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtSuperDev.java
@@ -21,8 +21,8 @@ import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.wisepersist.gradle.plugins.gwt.internal.GwtSuperDevOptionsImpl;
@@ -95,7 +95,7 @@ public class GwtSuperDev extends AbstractGwtActionTask implements
   }
 
   /** {@inheritDoc} */
-  @OutputDirectory
+  @Internal
   @Override
   public File getWorkDir() {
     return options.getWorkDir();


### PR DESCRIPTION
This PR aims to fix #36.

* The `work` and `cache` directories have been marked as internal, so they don't end up in the task outputs.
* The `extra` and `gen` have been made optional and the defaults have been removed. This way, these directories and their contents are only created when explicitly configured.