### PR TITLE
#47 Not setting gwtVersion will not cause a warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ gwt-unitCache/
 /doc/javadoc/
 /doc/__output__/
 /.dnconfig
+/eclipse.xml

--- a/build.gradle
+++ b/build.gradle
@@ -170,3 +170,7 @@ tasks.eclipse.doLast {
     project.file('.settings/org.eclipse.core.resources.prefs') << "eclipse.preferences.version=1\nencoding/<project>=$encoding\n";
   }
 }
+
+tasks['eclipse'].doLast {
+    mkdir 'build/pluginUnderTestMetadata'
+}

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtActionTask.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtActionTask.java
@@ -15,12 +15,11 @@
  */
 package org.wisepersist.gradle.plugins.gwt;
 
-import static org.wisepersist.gradle.plugins.gwt.internal.GwtVersion.parseOrNull;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
@@ -123,7 +122,7 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
           }
 
           argIfSet("-XjsInteropMode", getJsInteropMode());
-          if (doesSupportJsInteropExports(parseOrNull(getGwtVersion()))) {
+          if (doesSupportJsInteropExports(GwtVersion.parse(getGwtVersion()))) {
             argOnOff(getJsInteropExports().shouldGenerate(),
                 "-generateJsInteropExports",
                 "-nogenerateJsInteropExports");

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
@@ -33,8 +33,6 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.plugins.ide.eclipse.EclipsePlugin;
-import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.wisepersist.gradle.plugins.gwt.internal.GwtVersion;
 
 public class GwtBasePlugin implements Plugin<Project> {
@@ -109,7 +107,7 @@ public class GwtBasePlugin implements Plugin<Project> {
       }
       testSourceSet.setRuntimeClasspath(runtimeClasspath);
 
-      final GwtVersion parsedGwtVersion = parseGwtVersion();
+      final GwtVersion parsedGwtVersion = GwtVersion.parse(extension.getGwtVersion());
       final int major =
           (parsedGwtVersion == null) ? 2 : parsedGwtVersion.getMajor();
       final int minor =
@@ -121,7 +119,9 @@ public class GwtBasePlugin implements Plugin<Project> {
         }
       }
 
-      if (parsedGwtVersion != null) {
+      if (parsedGwtVersion == null) {
+        logger.debug("No automatic adding of GWT dependencies because gwtVersion is null or empty.");
+      } else {
         project.getDependencies().add(GWT_SDK_CONFIGURATION,
             gwtDependency(GWT_DEV, parsedGwtVersion));
         project.getDependencies().add(GWT_SDK_CONFIGURATION,
@@ -146,15 +146,6 @@ public class GwtBasePlugin implements Plugin<Project> {
       }
 
     });
-  }
-
-  private GwtVersion parseGwtVersion() {
-    try {
-      return GwtVersion.parse(extension.getGwtVersion());
-    } catch (final IllegalArgumentException e) {
-      logger.warn(e.getMessage());
-      return null;
-    }
   }
 
   private String gwtDependency(final String artifactId,

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtCompile.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtCompile.java
@@ -41,6 +41,7 @@ public class GwtCompile extends AbstractGwtCompile {
     return false;
   }
 
+  @Override
   protected void configure(final GwtCompileOptions options) {
     super.configure(options);
 

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersion.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersion.java
@@ -61,7 +61,7 @@ public final class GwtVersion {
       throw new IllegalArgumentException(
           format(PARSING_ERROR_MESSAGE_FORMAT, gwtVersion));
     }
-    throw new IllegalArgumentException("GWT version is is null or empty.");
+    throw new IllegalArgumentException("GWT version is null or empty.");
   }
 
   public int getMajor() {

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersion.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersion.java
@@ -25,43 +25,29 @@ public final class GwtVersion {
   /**
    * @param gwtVersion the gwt version string to be parsed
    * @return a newly created {@linkplain GwtVersion} instance representing
-   * the parsed GWT version string argument, or {@code null} if parsing failed
-   */
-  public static GwtVersion parseOrNull(final String gwtVersion) {
-    try {
-      return GwtVersion.parse(gwtVersion);
-    } catch (final IllegalArgumentException e) {
-      return null;
-    }
-  }
-
-  /**
-   * @param gwtVersion the gwt version string to be parsed
-   * @return a newly created {@linkplain GwtVersion} instance representing
-   * the parsed GWT version string argument
+   * the parsed GWT version string argument. null if gwtVersion is null or empty.
    * @throws IllegalArgumentException if any of the passed arguments are invalid
    */
   public static GwtVersion parse(final String gwtVersion) {
-    if ((gwtVersion != null) && !gwtVersion.isEmpty()) {
-      try {
-        final String[] versionParts = gwtVersion.split("\\.", 3);
-        if (versionParts.length >= 3) {
-          return new GwtVersion(Integer.parseUnsignedInt(versionParts[0]),
-              Integer.parseUnsignedInt(versionParts[1]),
-              versionParts[2]);
-        } else if (versionParts.length >= 2) {
-          return new GwtVersion(Integer.parseUnsignedInt(versionParts[0]),
-              Integer.parseUnsignedInt(versionParts[1]),
-              "0");
-        }
-      } catch (final NumberFormatException e) {
-        throw new IllegalArgumentException(
-            format(PARSING_ERROR_MESSAGE_FORMAT, gwtVersion), e);
-      }
-      throw new IllegalArgumentException(
-          format(PARSING_ERROR_MESSAGE_FORMAT, gwtVersion));
+    if (gwtVersion == null || gwtVersion.trim().isEmpty()) {
+        return null;
     }
-    throw new IllegalArgumentException("GWT version is null or empty.");
+    try {
+      final String[] versionParts = gwtVersion.split("\\.", 3);
+      if (versionParts.length >= 3) {
+        return new GwtVersion(Integer.parseUnsignedInt(versionParts[0]),
+            Integer.parseUnsignedInt(versionParts[1]),
+            versionParts[2]);
+      } else if (versionParts.length >= 2) {
+        return new GwtVersion(Integer.parseUnsignedInt(versionParts[0]),
+            Integer.parseUnsignedInt(versionParts[1]),
+            "0");
+      }
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException(
+          format(PARSING_ERROR_MESSAGE_FORMAT, gwtVersion), e);
+    }
+    throw new IllegalArgumentException(format(PARSING_ERROR_MESSAGE_FORMAT, gwtVersion));
   }
 
   public int getMajor() {

--- a/src/test/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersionTest.java
+++ b/src/test/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersionTest.java
@@ -1,0 +1,46 @@
+package org.wisepersist.gradle.plugins.gwt.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wisepersist.gradle.plugins.gwt.internal.GwtVersion;
+
+public class GwtVersionTest {
+
+    @Test
+    public void valid() {
+        GwtVersion v = GwtVersion.parse("2.5");
+        
+        Assert.assertEquals(2, v.getMajor());
+        Assert.assertEquals(5, v.getMinor());
+        Assert.assertEquals("2.5.0", v.toString());
+    }
+    
+    @Test
+    public void patch() {
+        GwtVersion v = GwtVersion.parse("2.5.1-ABC");
+
+        Assert.assertEquals("1-ABC", v.getPatch());
+        Assert.assertEquals("2.5.1-ABC", v.toString());
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void invalid() {
+        GwtVersion.parse("0");
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void notNumeric() {
+        GwtVersion.parse("a.b");
+    }
+    
+    @Test
+    public void empty() {
+        Assert.assertNull(GwtVersion.parse(""));
+        Assert.assertNull(GwtVersion.parse(" \t"));
+    }
+    
+    @Test
+    public void isNull() {
+        Assert.assertNull(GwtVersion.parse(null));
+    }
+}


### PR DESCRIPTION
but setting an illegal value for gwtVersion will cause an exception
(instead of warning)
GwtVersion.parseOrNull() removed.
New testcase.