### PR TITLE
Use org.gwtproject as group ID for GWT >= 2.10

### DIFF
--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtActionTask.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/AbstractGwtActionTask.java
@@ -176,8 +176,7 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
   private boolean doesSupportJsInteropExports(
       final GwtVersion parsedGwtVersion) {
     return (parsedGwtVersion != null) &&
-        (parsedGwtVersion.getMajor() >= 2) &&
-        (parsedGwtVersion.getMinor() >= 8);
+        (parsedGwtVersion.isAtLeast(2, 8));
   }
 
   @Optional

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/GwtBasePlugin.java
@@ -51,7 +51,8 @@ public class GwtBasePlugin implements Plugin<Project> {
 
   public static final String TASK_GWT_SUPER_DEV = "gwtSuperDev";
 
-  public static final String GWT_GROUP = "com.google.gwt";
+  public static final String GWT_GROUP_GOOGLE = "com.google.gwt";
+  public static final String GWT_GROUP_OSS = "org.gwtproject";
   public static final String GWT_DEV = "gwt-dev";
   public static final String GWT_USER = "gwt-user";
   public static final String GWT_CODESERVER = "gwt-codeserver";
@@ -108,12 +109,8 @@ public class GwtBasePlugin implements Plugin<Project> {
       testSourceSet.setRuntimeClasspath(runtimeClasspath);
 
       final GwtVersion parsedGwtVersion = GwtVersion.parse(extension.getGwtVersion());
-      final int major =
-          (parsedGwtVersion == null) ? 2 : parsedGwtVersion.getMajor();
-      final int minor =
-          (parsedGwtVersion == null) ? 5 : parsedGwtVersion.getMinor();
 
-      if ((major == 2 && minor >= 5) || major > 2) {
+      if (parsedGwtVersion == null || parsedGwtVersion.isAtLeast(2, 5)) {
         if (extension.isCodeserver()) {
           createSuperDevModeTask(project);
         }
@@ -130,7 +127,7 @@ public class GwtBasePlugin implements Plugin<Project> {
             .add(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME,
                 gwtDependency(GWT_SERVLET, parsedGwtVersion));
 
-        if ((major == 2 && minor >= 5) || major > 2) {
+        if (parsedGwtVersion.isAtLeast(2, 5)) {
           if (extension.isCodeserver()) {
             project.getDependencies().add(GWT_CONFIGURATION,
                 gwtDependency(GWT_CODESERVER, parsedGwtVersion));
@@ -150,7 +147,8 @@ public class GwtBasePlugin implements Plugin<Project> {
 
   private String gwtDependency(final String artifactId,
       final GwtVersion gwtVersion) {
-    return format("%s:%s:%s", GWT_GROUP, artifactId, gwtVersion.toString());
+    String group = gwtVersion.isAtLeast(2, 10) ? GWT_GROUP_OSS : GWT_GROUP_GOOGLE;
+    return format("%s:%s:%s", group, artifactId, gwtVersion);
   }
 
   private GwtPluginExtension configureGwtExtension(final File buildDir) {

--- a/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersion.java
+++ b/src/main/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersion.java
@@ -69,4 +69,8 @@ public final class GwtVersion {
   public String toString() {
     return format("%d.%d.%s", major, minor, patch);
   }
+
+  public boolean isAtLeast(int majorMin, int minorMin) {
+    return major > majorMin || (major == majorMin && minor >= minorMin);
+  }
 }

--- a/src/test/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersionTest.java
+++ b/src/test/java/org/wisepersist/gradle/plugins/gwt/internal/GwtVersionTest.java
@@ -22,7 +22,16 @@ public class GwtVersionTest {
         Assert.assertEquals("1-ABC", v.getPatch());
         Assert.assertEquals("2.5.1-ABC", v.toString());
     }
-    
+
+    @Test
+    public void comparison() {
+        GwtVersion v = GwtVersion.parse("2.5.1-ABC");
+
+        Assert.assertFalse("Should be less than 3.0", v.isAtLeast(3, 0));
+        Assert.assertFalse("Should be less than 2.6", v.isAtLeast(2, 6));
+        Assert.assertTrue("Should be at least 2.5", v.isAtLeast(2, 5));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void invalid() {
         GwtVersion.parse("0");


### PR DESCRIPTION
Fixes #60 

EDIT: checked with running code in SuperDev mode and with compiling to JS, both worked fine. Also all artifacts from `./gradlew :dependencies` show the correct group ID.