### PR TITLE
Add -style parameter to SuperDev Mode

### DIFF
--- a/src/main/java/org/docstr/gradle/plugins/gwt/GwtSuperDev.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/GwtSuperDev.java
@@ -15,17 +15,13 @@
  */
 package org.docstr.gradle.plugins.gwt;
 
-import java.io.File;
-import java.util.concurrent.Callable;
+import org.docstr.gradle.plugins.gwt.internal.GwtSuperDevOptionsImpl;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
-import org.docstr.gradle.plugins.gwt.internal.GwtSuperDevOptionsImpl;
+import org.gradle.api.tasks.*;
+
+import java.io.File;
+import java.util.concurrent.Callable;
 
 /**
  * Task to run the GWT Super Dev Mode.
@@ -61,6 +57,7 @@ public class GwtSuperDev extends AbstractGwtActionTask implements
     argIfSet("-compileTestRecompiles", getCompileTestRecompiles());
     argIfSet("-launcherDir", getLauncherDir());
     argIfSet("-logLevel", getLogLevel());
+    argIfSet("-style", getStyle());
     argOnOff(getClosureFormattedOutput(), "-XclosureFormattedOutput",
         "-XnoclosureFormattedOutput");
   }
@@ -245,5 +242,19 @@ public class GwtSuperDev extends AbstractGwtActionTask implements
   @Override
   public void setClosureFormattedOutput(Boolean closureFormattedOutput) {
     options.setClosureFormattedOutput(closureFormattedOutput);
+  }
+
+  /** {@inheritDoc} */
+  @Optional
+  @Input
+  @Override
+  public Style getStyle() {
+    return options.getStyle();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setStyle(Style style) {
+    options.setStyle(style);
   }
 }

--- a/src/main/java/org/docstr/gradle/plugins/gwt/GwtSuperDevOptions.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/GwtSuperDevOptions.java
@@ -119,4 +119,8 @@ public interface GwtSuperDevOptions {
    * @param closureFormattedOutput The closure formatted output.
    */
   void setClosureFormattedOutput(Boolean closureFormattedOutput);
+
+  Style getStyle();
+
+  void setStyle(Style style);
 }

--- a/src/main/java/org/docstr/gradle/plugins/gwt/internal/GwtSuperDevOptionsImpl.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/internal/GwtSuperDevOptionsImpl.java
@@ -15,8 +15,10 @@
  */
 package org.docstr.gradle.plugins.gwt.internal;
 
-import java.io.File;
 import org.docstr.gradle.plugins.gwt.GwtSuperDevOptions;
+import org.docstr.gradle.plugins.gwt.Style;
+
+import java.io.File;
 
 /**
  * Default implementation of {@link GwtSuperDevOptions}.
@@ -36,6 +38,7 @@ public class GwtSuperDevOptionsImpl implements GwtSuperDevOptions {
   private File launcherDir;
   // -X[no]closureFormattedOutput
   private Boolean closureFormattedOutput;
+  private Style style;
 
   /** {@inheritDoc} */
   @Override
@@ -167,5 +170,17 @@ public class GwtSuperDevOptionsImpl implements GwtSuperDevOptions {
   @Override
   public void setClosureFormattedOutput(Boolean closureFormattedOutput) {
     this.closureFormattedOutput = closureFormattedOutput;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Style getStyle() {
+    return style;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setStyle(Style style) {
+    this.style = style;
   }
 }


### PR DESCRIPTION
SuperDev Mode has [a `-style` parameter](https://www.gwtproject.org/articles/superdevmode.html), which currently cannot be used with this plugin. This PR adds this parameter.