### PR TITLE
Fix: Add -style parameter to convention Mapping

### DIFF
--- a/src/main/java/org/docstr/gradle/plugins/gwt/GwtSuperDev.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/GwtSuperDev.java
@@ -82,6 +82,8 @@ public class GwtSuperDev extends AbstractGwtActionTask implements
         (Callable<Integer>) () -> options.getCompileTestRecompiles());
     conventionMapping.map("launcherDir",
         (Callable<File>) () -> options.getLauncherDir());
+    conventionMapping.map("style",
+        (Callable<Style>) () -> options.getStyle());
     conventionMapping
         .map("closureFormattedOutput", options::getClosureFormattedOutput);
   }


### PR DESCRIPTION
I oversaw this line, which is actually required to make the change of #69 work.