### PR TITLE
Allow using Java version from toolchain

### DIFF
--- a/doc/setup-and-configuration/Configuration References.md
+++ b/doc/setup-and-configuration/Configuration References.md
@@ -102,6 +102,18 @@ gwt {
 }
 ```
 
+### Use JVM from Gradle's Java toolchain
+
+In case you are specifying a [Java toolchain](https://docs.gradle.org/current/userguide/toolchains.html)
+to compile your Java files with a higher version of Java than the one running Gradle, GWT compilation might fail.
+To avoid this you can align the Java versions use for Java and GWT compilation using
+
+```
+gwt {
+    useToolchain = true
+}
+```
+
 ### Log level
 
 The log level of GWT tasks is automatically configured depending on Gradle's log level. So by default this is "ERROR".

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.1.26-ggb
+version = 1.1.27

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.1.27
+version = 1.1.26-ggb


### PR DESCRIPTION
In case you are specifying a [Java toolchain](https://docs.gradle.org/current/userguide/toolchains.html)
to compile your Java files with a higher version of Java than the one running Gradle, GWT compilation might fail.

This allows plugins users to avoid that -- I made it configurable since I'm not sure if that's a good idea by default (e.g. the someone may want to run Gradle and GWT in Java 11 and default Java compilation in Java 8 ...)