### PR TITLE
Fix: checkGwt task does not delegate to GwtCheck class #72

### DIFF
--- a/src/main/java/org/docstr/gradle/plugins/gwt/GwtCompilerPlugin.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/GwtCompilerPlugin.java
@@ -51,7 +51,7 @@ public class GwtCompilerPlugin implements Plugin<Project> {
               project.getTasks().named(JavaPlugin.PROCESS_RESOURCES_TASK_NAME));
     });
 
-    project.getTasks().register(TASK_CHECK, task -> {
+    project.getTasks().register(TASK_CHECK, GwtCheck.class, task -> {
       task.setDescription("Runs the GWT compiler to validate the relevant sources");
       task.dependsOn(project.getTasks().named(JavaPlugin.COMPILE_JAVA_TASK_NAME),
               project.getTasks().named(JavaPlugin.PROCESS_RESOURCES_TASK_NAME));


### PR DESCRIPTION
Added back the missing task class reference to fix #72 .