### PR TITLE
add -setProperty gwt compiler option

### DIFF
--- a/doc/setup/Configuration References.md
+++ b/doc/setup/Configuration References.md
@@ -129,3 +129,15 @@ gwt {
 ```
 
 The available log levels are defined in the enum [LogLevel](../javadoc/org/docstr/gradle/plugins/gwt/LogLevel.html).
+
+### Using the setProperty Compiler Flag
+
+GWT allows you to set the value of a property using the `-setProperty` flag. This is accomplished here by:
+
+```
+gwt {
+    compiler {
+        setProperties = ["user.agent=safari", "locale=default"]
+    }
+}
+```

--- a/src/main/java/org/docstr/gradle/plugins/gwt/AbstractGwtCompile.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/AbstractGwtCompile.java
@@ -16,6 +16,7 @@
 package org.docstr.gradle.plugins.gwt;
 
 import java.io.File;
+import java.util.List;
 import java.util.concurrent.Callable;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.tasks.Input;
@@ -51,6 +52,11 @@ public class AbstractGwtCompile extends AbstractGwtTask implements
     argIfEnabled(getDisableGeneratingOnShards(), "-XdisableGeneratingOnShards");
 
     argIfSet("-optimize", getOptimize());
+
+    for (String property: getSetProperties()) {
+      args("-setProperty", property);
+    }
+
     argIfEnabled(getDisableAggressiveOptimization(),
         "-XdisableAggressiveOptimization");
     argIfEnabled(getDisableClassMetadata(), "-XdisableClassMetadata");
@@ -432,5 +438,19 @@ public class AbstractGwtCompile extends AbstractGwtTask implements
   @Override
   public void setClosureFormattedOutput(Boolean closureFormattedOutput) {
     options.setClosureFormattedOutput(closureFormattedOutput);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setSetProperties(List<String> properties) {
+    options.setSetProperties(properties);
+  }
+
+  /** {@inheritDoc} */
+  @Optional
+  @Input
+  @Override
+  public List<String> getSetProperties() {
+    return options.getSetProperties();
   }
 }

--- a/src/main/java/org/docstr/gradle/plugins/gwt/GwtCompile.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/GwtCompile.java
@@ -16,6 +16,7 @@
 package org.docstr.gradle.plugins.gwt;
 
 import java.io.File;
+import java.util.List;
 import java.util.concurrent.Callable;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
@@ -93,5 +94,6 @@ public class GwtCompile extends AbstractGwtCompile {
         (Callable<File>) () -> options.getSaveSourceOutput());
     conventionMapping
         .map("closureFormattedOutput", options::getClosureFormattedOutput);
+    conventionMapping.map("setProperties", options::getSetProperties);
   }
 }

--- a/src/main/java/org/docstr/gradle/plugins/gwt/GwtCompileOptions.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/GwtCompileOptions.java
@@ -16,6 +16,7 @@
 package org.docstr.gradle.plugins.gwt;
 
 import java.io.File;
+import java.util.List;
 
 
 /**
@@ -236,4 +237,14 @@ public interface GwtCompileOptions {
    * @param closureFormattedOutput The closure formatted output.
    */
   void setClosureFormattedOutput(Boolean closureFormattedOutput);
+
+  /**
+   * Set the values of a property in the form of propertyName=value1[,value2...].
+   * Example: -setProperties = ["user.agent=safari", "locale=default"]
+   * would add the parameters -setProperty user.agent=safari -setProperty locale=default
+   * @param properties The list of properties to be set
+   */
+  void setSetProperties(List<String> properties);
+
+  List<String> getSetProperties();
 }

--- a/src/main/java/org/docstr/gradle/plugins/gwt/internal/GwtCompileOptionsImpl.java
+++ b/src/main/java/org/docstr/gradle/plugins/gwt/internal/GwtCompileOptionsImpl.java
@@ -16,6 +16,8 @@
 package org.docstr.gradle.plugins.gwt.internal;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 import org.docstr.gradle.plugins.gwt.GwtCompileOptions;
 import org.docstr.gradle.plugins.gwt.Namespace;
 import org.docstr.gradle.plugins.gwt.Style;
@@ -61,6 +63,7 @@ public class GwtCompileOptionsImpl implements GwtCompileOptions {
   private File saveSourceOutput;
   // -X[no]closureFormattedOutput
   private Boolean closureFormattedOutput;
+  private List<String> properties = Collections.emptyList();
 
   /** {@inheritDoc} */
   @Override
@@ -362,5 +365,17 @@ public class GwtCompileOptionsImpl implements GwtCompileOptions {
   @Override
   public void setClosureFormattedOutput(Boolean closureFormattedOutput) {
     this.closureFormattedOutput = closureFormattedOutput;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setSetProperties(List<String> properties) {
+    this.properties = properties;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public List<String> getSetProperties() {
+    return this.properties;
   }
 }


### PR DESCRIPTION
Adds the "-setProperty" parameter to the gwt compiler options. This partially addresses #4 