### PR TITLE
Fix gwt test

### DIFF
--- a/plugin/src/main/java/org/docstr/gwt/GwtTestConfig.java
+++ b/plugin/src/main/java/org/docstr/gwt/GwtTestConfig.java
@@ -60,36 +60,36 @@ public class GwtTestConfig implements Action<Test> {
       testOptions.getCacheDir().set(extension.getCacheDir().getOrNull());
     }
 
-    // Retrieve the main source set
-    SourceSetContainer sourceSets = project.getExtensions()
-        .getByType(SourceSetContainer.class);
-
-    SourceSet mainSourceSet = sourceSets.getByName(
-        SourceSet.MAIN_SOURCE_SET_NAME);
-    Set<File> mainSourcePaths = mainSourceSet.getAllSource().getSrcDirs();
-    FileCollection mainOutputClasspath = mainSourceSet.getOutput()
-        .getClassesDirs()
-        .plus(project.files(mainSourceSet.getOutput().getResourcesDir()));
-
-    SourceSet testSourceSet = sourceSets.getByName(
-        SourceSet.TEST_SOURCE_SET_NAME);
-    Set<File> testSourcePaths = testSourceSet.getAllSource().getSrcDirs();
-    FileCollection testOutputClasspath = testSourceSet.getOutput()
-        .getClassesDirs()
-        .plus(project.files(testSourceSet.getOutput().getResourcesDir()));
-
-    // Ensure the classpath includes compiled classes, resources, and source files
-    test.setClasspath(project.files(
-        mainSourcePaths,
-        mainOutputClasspath,
-        mainSourceSet.getRuntimeClasspath(),
-
-        testSourcePaths,
-        testOutputClasspath,
-        testSourceSet.getRuntimeClasspath()
-    ));
-
     project.afterEvaluate(p -> {
+      // Retrieve the main source set
+      SourceSetContainer sourceSets = project.getExtensions()
+              .getByType(SourceSetContainer.class);
+
+      SourceSet mainSourceSet = sourceSets.getByName(
+              SourceSet.MAIN_SOURCE_SET_NAME);
+      Set<File> mainSourcePaths = mainSourceSet.getAllSource().getSrcDirs();
+      FileCollection mainOutputClasspath = mainSourceSet.getOutput()
+              .getClassesDirs()
+              .plus(project.files(mainSourceSet.getOutput().getResourcesDir()));
+
+      SourceSet testSourceSet = sourceSets.getByName(
+              SourceSet.TEST_SOURCE_SET_NAME);
+      Set<File> testSourcePaths = testSourceSet.getAllSource().getSrcDirs();
+      FileCollection testOutputClasspath = testSourceSet.getOutput()
+              .getClassesDirs()
+              .plus(project.files(testSourceSet.getOutput().getResourcesDir()));
+
+      // Ensure the classpath includes compiled classes, resources, and source files
+      test.setClasspath(project.files(
+              mainSourcePaths,
+              mainOutputClasspath,
+              mainSourceSet.getRuntimeClasspath(),
+
+              testSourcePaths,
+              testOutputClasspath,
+              testSourceSet.getRuntimeClasspath()
+      ));
+
       String gwtArgs = testOptions.getParameterString();
       test.systemProperty("gwt.args", gwtArgs);
       Logger log = project.getLogger();

--- a/plugin/src/main/java/org/docstr/gwt/options/GwtTestOptions.java
+++ b/plugin/src/main/java/org/docstr/gwt/options/GwtTestOptions.java
@@ -40,6 +40,7 @@ public abstract class GwtTestOptions extends AbstractBaseOptions {
     dirArgIfSet(builder, "-gen", getGen());
 
     argIfSet(builder, "-logLevel", getLogLevel());
+    argIfSet(builder, "-sourceLevel", getSourceLevel());
 
     argIfSet(builder, "-port", getPort());
     argIfSet(builder, "-whitelist", getWhitelist());


### PR DESCRIPTION
- Fix: When running GwtTest, if a GWTTestCase is defined, the code in GWTTestCase also needs to be transpiled from Java to JavaScript. During this process, specifying the JDK version used to write the code is crucial to ensure proper transpilation. When executing tests through JUnit, parameters are passed using the gwt.args property. However, it seems the sourceLevel parameter, which indicates the Java version, is missing (though other parameters have not been verified). The latest GWT supports syntax introduced in JDK 11 and later. Without this option, modern constructs like var or enhanced switch expressions cannot be used in GWTTestCase code.


- Fix: SourceSet can be added in the user's build script. For example, when using 'dagger-gwt', the annotation processor generates Java files, which can be included by adding the following configuration to the Gradle build script(in kotlin format):

```kotlin
sourceSets {
  named("main") {
    java.srcDir("build/generated/sources/annotationProcessor/java/main")
  }
  named("test") {
    java.srcDir("build/generated/sources/annotationProcessor/java/test")
  }
}
```
This configuration works correctly in DevMode and during builds but fails during test because the specified paths are not applied to the task, resulting in an error. The current classpath setup is executed before the user's build script runs, causing the added SourceSet to be omitted.

To address this, the classpath configuration has been deferred to occur after the user's build script execution.