### PR TITLE
Support for default source and public paths

### DIFF
--- a/plugin/src/main/java/org/docstr/gwt/GwtCompileConfig.java
+++ b/plugin/src/main/java/org/docstr/gwt/GwtCompileConfig.java
@@ -68,11 +68,12 @@ public class GwtCompileConfig implements Action<GwtCompileTask> {
   }
 
   static File findModuleFile(String moduleName, Set<File> sourceFiles) {
+    String moduleFileName = moduleName.replace('.', '/') + ".gwt.xml";
     for (File file : sourceFiles) {
       log.info("findModuleFile - file: {}, module: {}",
           file.getAbsolutePath(), moduleName);
       if (file.getAbsolutePath().replaceAll("\\\\", "/")
-          .endsWith(moduleName.replace('.', '/') + ".gwt.xml")) {
+          .endsWith(moduleFileName)) {
         return file;
       }
     }
@@ -121,20 +122,30 @@ public class GwtCompileConfig implements Action<GwtCompileTask> {
 
       // Extract the source paths from the GWT module XML file
       NodeList sourceNodes = doc.getElementsByTagName("source");
-      for (int i = 0; i < sourceNodes.getLength(); i++) {
-        String path = sourceNodes.item(i).getAttributes().getNamedItem("path")
-            .getNodeValue();
-        File sourceDir = new File(moduleParent, path);
+      if(sourceNodes.getLength() == 0) {
+        File sourceDir = new File(moduleParent, "client");
         sourcePaths.add(sourceDir);
+      } else {
+        for(int i = 0; i < sourceNodes.getLength(); i++) {
+          String path = sourceNodes.item(i).getAttributes().getNamedItem("path")
+                  .getNodeValue();
+          File sourceDir = new File(moduleParent, path);
+          sourcePaths.add(sourceDir);
+        }
       }
 
       // Extract the public paths from the GWT module XML file
       NodeList publicNodes = doc.getElementsByTagName("public");
-      for (int i = 0; i < publicNodes.getLength(); i++) {
-        String path = publicNodes.item(i).getAttributes().getNamedItem("path")
-            .getNodeValue();
-        File publicDir = new File(moduleParent, path);
-        sourcePaths.add(publicDir);
+      if(publicNodes.getLength() == 0) {
+        File sourceDir = new File(moduleParent, "public");
+        sourcePaths.add(sourceDir);
+      } else {
+        for(int i = 0; i < publicNodes.getLength(); i++) {
+          String path = publicNodes.item(i).getAttributes().getNamedItem("path")
+                  .getNodeValue();
+          File publicDir = new File(moduleParent, path);
+          sourcePaths.add(publicDir);
+        }
       }
     } catch (Exception e) {
       log.error("Error reading GWT module file: {}", moduleFile, e);


### PR DESCRIPTION
Hi,

we've been using the v1 version of this plugin for about a 6 months I guess (thanks!), and we are considering moving to v2.

We have multiple GWT modules in one Gradle source set, and only one of them has an `entry-point` element.  So guessing the source path from that doesn't work for us.  We could add the `<source path="client"/>` to all the modules, but that seems unnecessary, because:

As mentioned in
https://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html if no `source` or `public` element is defined in a module XML file, the `client` and `public` subpackage is implicitly added to the source/public path as if `<source path="client" />` or `<public path="public">` had been found in the XML.

So, that is what this PR is about.  What do you think?
