### PR TITLE
In tests, use TreeSet that orders the same on all OSes

### DIFF
--- a/plugin/src/main/java/org/docstr/gwt/GwtCompileConfig.java
+++ b/plugin/src/main/java/org/docstr/gwt/GwtCompileConfig.java
@@ -16,6 +16,7 @@
 package org.docstr.gwt;
 
 import java.io.File;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
@@ -93,7 +94,7 @@ public class GwtCompileConfig implements Action<GwtCompileTask> {
    * found in the XML.
    */
   TreeSet<File> extractSourcePaths(File moduleFile) {
-    TreeSet<File> sourcePaths = new TreeSet<>();
+    TreeSet<File> sourcePaths = new TreeSet<>(Comparator.comparing(File::getName));
     sourcePaths.add(moduleFile);
     try {
       DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();


### PR DESCRIPTION
In my previous PR I broke the tests.  Sorry about that.  I though they were broken in main branch, but they were only broken on Windows.

Here's what I learned.

```java
import java.io.File;
import java.util.TreeSet;

final String path = "/foo";
final TreeSet<File> t = new TreeSet<>();

// The order of add calls doesn't matter here.
// Just mimicking the order of extractSourcePaths.
t.add(new File(path, "MyModule.gwt.xml"));
t.add(new File(path, "client"));

System.out.println(t);
// On Windows: [\foo\client, \foo\MyModule.gwt.xml]
// On Linux:   [/foo/MyModule.gwt.xml, /foo/client]
```

For me, the "Linux" here was just `docker run -it azul/zulu-openjdk:17-latest jshell`. I'm now using zulu 17 on Windows, too, since that seems to be on your CI.

So, on Windows, "c" comes before "M", but some of the tests assume "M" come before "c".

Windows and Linux Java agree on the order, if the `TreeSet` is of `String`:

```java
final TreeSet<String> s = new TreeSet<>();
// Again, order does not matter.
s.add("M");
s.add("c");
System.out.println(s);
// On Windows: [M, c]
// On Linux: [M, c]
```

That's the back story for this PR.  Now the tests pass for us poor Windows users, too.  I hope I didn't break them for you or CI.