### PR TITLE
Allow user to configure which test tasks to configure

### DIFF
--- a/plugin/src/main/java/org/docstr/gwt/GwtPluginExtension.java
+++ b/plugin/src/main/java/org/docstr/gwt/GwtPluginExtension.java
@@ -93,4 +93,13 @@ public abstract class GwtPluginExtension extends AbstractBaseOptions {
   public void superDev(Action<? super SuperDevOptions> action) {
     action.execute(getSuperDev());
   }
+
+  /**
+   * Configure the gwt test options.
+   *
+   * @param action The action to configure the gwt options
+   */
+  public void gwtTest(Action<? super GwtTestOptions> action) {
+    action.execute(getGwtTest());
+  }
 }

--- a/plugin/src/main/java/org/docstr/gwt/options/GwtTestOptions.java
+++ b/plugin/src/main/java/org/docstr/gwt/options/GwtTestOptions.java
@@ -18,6 +18,7 @@ package org.docstr.gwt.options;
 import java.io.File;
 import org.docstr.gwt.AbstractBaseOptions;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 /**
@@ -235,4 +236,18 @@ public abstract class GwtTestOptions extends AbstractBaseOptions {
    * @return The user agents
    */
   public abstract Property<String> getUserAgents();
+
+  /**
+   * Names of the test tasks to configure for GWT.
+   * <p>
+   *     This defaults to an empty list.
+   *     For backwards compatibility, an empty list is interpreted to mean all tasks of type {@link org.gradle.api.tasks.testing.Test Test}.
+   * </p>
+   * <p>
+   *     To disable any test task configuration, this can be set to {@code null}.
+   * </p>
+   *
+   * @return The test task names.
+   */
+  public abstract ListProperty<String> getTestTasks();
 }


### PR DESCRIPTION
Hi,

the plugin configures all tasks of type Test, and it seems to interfere with how Gradle sets up the testing frameworks.

I've created a small but representative [demo app](https://github.com/vmj/gradle-jvm-test-suites-with-gwt) that is using [JVM Test Suites](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html).  Which is what we use in my current project.

If you checkout the demo app code and try to follow the README, you will notice that some of the test suites fail to initialize any of the tests.

To make them work:

 1. In your checkout of the `gwt-gradle-plugin`, switch to this PR branch
 2. In the demo app, edit the `settings.gradle` to include the plugin build
 3. In the demo app, edit the `build.gradle` to disable the test task configuration

Let me know what you think.

