### PR TITLE
Add to classpath in AbstractBaseTask

### DIFF
--- a/plugin/src/main/java/org/docstr/gwt/AbstractBaseTask.java
+++ b/plugin/src/main/java/org/docstr/gwt/AbstractBaseTask.java
@@ -116,11 +116,11 @@ public abstract class AbstractBaseTask extends JavaExec {
         .plus(getProject().files(mainSourceSet.getOutput().getResourcesDir()));
 
     // Ensure the classpath includes compiled classes, resources, and source files
-    setClasspath(getProject().files(
+    classpath(
         allMainSourcePaths,
         outputClasspath,
         getProject().getConfigurations().getByName("runtimeClasspath")
-    ));
+    );
 
     // Log the classpath
     Logger log = getProject().getLogger();

--- a/plugin/src/main/java/org/docstr/gwt/GwtTestConfig.java
+++ b/plugin/src/main/java/org/docstr/gwt/GwtTestConfig.java
@@ -79,15 +79,15 @@ public class GwtTestConfig implements Action<Test> {
         .plus(project.files(testSourceSet.getOutput().getResourcesDir()));
 
     // Ensure the classpath includes compiled classes, resources, and source files
-    test.setClasspath(project.files(
-        mainSourcePaths,
-        mainOutputClasspath,
-        mainSourceSet.getRuntimeClasspath(),
+    test.setClasspath(test.getClasspath().plus(project.files(
+            mainSourcePaths,
+            mainOutputClasspath,
+            mainSourceSet.getRuntimeClasspath(),
 
-        testSourcePaths,
-        testOutputClasspath,
-        testSourceSet.getRuntimeClasspath()
-    ));
+            testSourcePaths,
+            testOutputClasspath,
+            testSourceSet.getRuntimeClasspath()
+    )));
 
     String gwtArgs = testOptions.getParameterString();
     test.systemProperty("gwt.args", gwtArgs);


### PR DESCRIPTION
instead of overwriting it, so that users can configure additions to the tasks' classpath.

Closes #88