### PR TITLE
Test the plugin agains different Gradle versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check out their latest Chrome extension, [MindPane](https://mindpane.net/), whic
   on changes within GWT-specific code, optimizing the build process for faster
   iterations and more efficient resource usage.
 - **Configuration aligned with GWT compiler options** for ease of use
-- **Support for GWT 2.12+** and the latest Gradle 8.11
+- **Support for GWT 2.12+** and the latest Gradle 8.13 (minimum Gradle version is 8.1)
 - Built-in tasks for GWT compilation and dev mode
 
 ## Usage

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,8 @@ slf4j = "2.0.16"
 commons-io = "2.17.0"
 classgraph = "4.8.176"
 
-junit-jupiter = "5.10.3"
+# https://central.sonatype.com/artifact/org.junit.jupiter/junit-jupiter
+junit-jupiter = "5.11.4"
 assertj-core = "3.26.3"
 
 # https://plugins.gradle.org/plugin/io.freefair.lombok

--- a/plugin/src/test/java/org/docstr/gwt/GwtPluginFunctionalTest.java
+++ b/plugin/src/test/java/org/docstr/gwt/GwtPluginFunctionalTest.java
@@ -15,22 +15,57 @@
  */
 package org.docstr.gwt;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Set;
+
 import lombok.extern.slf4j.Slf4j;
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.jupiter.api.Test;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 
 /**
- * A simple functional test for the 'org.docstr.gwt' plugin.
+ * A functional test for the 'org.docstr.gwt' plugin.
+ *
+ * This will download (and cache) different versions of Gradle
+ * and try to build the sample-gwt-project (in resources).
  */
 @Slf4j
 class GwtPluginFunctionalTest extends AbstractGwtTest {
 
-  @Test
-  void canRunTask() throws IOException {
+  private static final Set<String> supportedGradleVersions = Set.of(
+          // https://gradle.org/releases/
+          // Only including the last patch release of each supported Gradle version.
+          // For example, you won't see 8.10.1 here because it was superseded by 8.10.2.
+          "8.13",   // Feb 25, 2025
+          "8.12.1", // Jan 24, 2025
+          "8.11.1", // Nov 20, 2024
+          "8.10.2", // Sep 23, 2024
+//          "8.9",    // Jul 11, 2024
+//          "8.8",    // May 31, 2024
+//          "8.7",    // Mar 22, 2024
+//          "8.6",    // Feb 02, 2024
+//          "8.5",    // Nov 29, 2024
+//          "8.4",    // Oct 29, 2023
+//          "8.3",    // Aug 17, 2023
+//          "8.2.1",  // Jul 10, 2023
+          "8.1.1"   // Apr 21, 2023
+
+          // This plugin is using JavaExecSpec getJvmArguments method,
+          // which was introduced in Gradle 8.1.
+          // So, these are currently not supported.
+          //"8.0.2", // Mar 03, 2023
+          //"7.6.4", // Feb 05, 2024 (latest 7.x)
+  );
+
+  @ParameterizedTest(name = "Can run gwtCompile task with Gradle {0}")
+  @FieldSource("supportedGradleVersions")
+  void canRunTask(String gradleVersion) throws IOException {
     /*
      * -------------------------------------------------------------------------
      * Given
@@ -44,11 +79,12 @@ class GwtPluginFunctionalTest extends AbstractGwtTest {
      * -------------------------------------------------------------------------
      */
     // Run the build
-    GradleRunner runner = GradleRunner.create();
-    runner.forwardOutput();
-    runner.withPluginClasspath();
-    runner.withArguments("gwtCompile", "--info");
-    runner.withProjectDir(projectDir);
+    GradleRunner runner = GradleRunner.create()
+            .withGradleVersion(gradleVersion)
+            .forwardOutput()
+            .withPluginClasspath()
+            .withArguments("gwtCompile", "--info")
+            .withProjectDir(projectDir);
     BuildResult result;
     try {
       result = runner.build();
@@ -63,6 +99,10 @@ class GwtPluginFunctionalTest extends AbstractGwtTest {
      * -------------------------------------------------------------------------
      */
     // Verify the result
+    assertThat(result.task(":gwtCompile"))
+            .isNotNull()
+            .extracting(BuildTask::getOutcome)
+            .isEqualTo(TaskOutcome.SUCCESS);
     assertTrue(result.getOutput().contains("Compilation succeeded"));
     assertTrue(result.getOutput().contains("Linking succeeded"));
   }


### PR DESCRIPTION
I included 8.1 (lowest supported) and 8.9 - 8.12 (latest four).  The versions between work, too, but are disabled just to save time/bandwith/space.

I removed the comment about Java versions.  If someone is using an old Gradle version, then it is probably obvious they can't use certain Java versions, regardless of this plugin.
