### PR TITLE
Futher enhancements:

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -24,14 +24,11 @@ repositories {
 }
 
 dependencies {
-  implementation libs.gwt.user
-  implementation libs.gwt.dev
-  implementation libs.gwt.codeserver
-
   // Use JUnit Jupiter for testing.
   testImplementation libs.junit.jupiter
   testImplementation libs.assertj.core
   testImplementation libs.commons.io
+  testImplementation libs.commons.lang
   testImplementation libs.classgraph
   testImplementation libs.slf4j.api
   testImplementation libs.slf4j.jdk14
@@ -50,7 +47,6 @@ gradlePlugin {
       displayName = 'GWT Gradle Plugin'
       description = 'Gradle plugin to support GWT related tasks.'
       tags.set(['gwt', 'gwt-gradle', 'gwt-gradle-plugin'])
-
     }
   }
 }
@@ -123,4 +119,8 @@ publishing {
 tasks.named('test') {
   // Use JUnit Jupiter for unit tests.
   useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+  options.deprecation = true
 }

--- a/plugin/src/main/java/org/docstr/gwt/GwtCompileConfig.java
+++ b/plugin/src/main/java/org/docstr/gwt/GwtCompileConfig.java
@@ -15,7 +15,6 @@
  */
 package org.docstr.gwt;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;

--- a/plugin/src/test/java/org/docstr/gwt/AbstractGwtTest.java
+++ b/plugin/src/test/java/org/docstr/gwt/AbstractGwtTest.java
@@ -15,8 +15,6 @@
  */
 package org.docstr.gwt;
 
-import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
-
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.Resource;
 import io.github.classgraph.ScanResult;
@@ -28,6 +26,7 @@ import java.io.Writer;
 import java.util.List;
 import java.util.logging.LogManager;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Strings;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -59,10 +58,10 @@ public abstract class AbstractGwtTest {
       List<Resource> resources = scanResult.getAllResources();
       for (Resource resource : resources) {
         String resourcePath = resource.getPath();
-        if (containsIgnoreCase(resourcePath, ".idea")
-            || containsIgnoreCase(resourcePath, "/.gradle/")
-            || containsIgnoreCase(resourcePath, "/gradle/")
-            || containsIgnoreCase(resourcePath, "gradlew")) {
+        if (Strings.CI.contains(resourcePath, ".idea")
+            || Strings.CI.contains(resourcePath, "/.gradle/")
+            || Strings.CI.contains(resourcePath, "/gradle/")
+            || Strings.CI.contains(resourcePath, "gradlew")) {
           // log.warn("Skipping path: {}", resourcePath);
           continue;
         }


### PR DESCRIPTION
1. Make the GWT version public to allow consumers the flexability to pull that version.
2. Add the GWT platform BOM to a second configuration.
3. Update both Jakarta and non-Jakarta builds to have the latest dependency. Used dynamic versions to make sure that the correct one is imported.
3. Removes GWT from the compile classspath. It pulls an old version of Xerces which breaks the Gradle tests.
4. Added a test to check the dependency resolution.
5. Imported commons lang to the test path (was transitively pulled by GWT). Resolved depreciation warnings.
6. Added deprecation warnings to the compiler.
7. 7. Prevented src/main/java being added to the resources sourceset, which ends up copying extra files into the final packaging (when for example a war or jar project is also being built). Implementers can add this in their build.gradle if needed.