### PR TITLE
Fix a few usage instructions in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ plugins {
 gwt {
   // Optional: Set the GWT version, defaults to 2.12.1
   // gwtVersion = '2.12.1'
-  modules ['<YOUR-GWT-MODULE>']
+  modules = ['<YOUR-GWT-MODULE>']
 }
 ```
 
@@ -60,14 +60,14 @@ buildscript {
     }
   }
   dependencies {
-    classpath "org.docstr.gwt:gwt-gradle-plugin:2.2.4"
+    classpath "org.docstr.gwt:org.docstr.gwt.gradle.plugin:2.2.4"
   }
 }
 
 apply plugin: "org.docstr.gwt"
 
 gwt {
-    modules ['<YOUR-GWT-MODULE>']
+    modules = ['<YOUR-GWT-MODULE>']
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ scmVersion {
     ])
     pre("fileUpdate", [
         file       : "README.md",
-        pattern    : { v, p -> /org\.docstr\.gwt:gwt-gradle-plugin:([\d.a-zA-Z-]+)/ },
-        replacement: { v, p -> "org.docstr.gwt:gwt-gradle-plugin:${v}" }
+        pattern    : { v, p -> /org\.docstr\.gwt:org\.docstr\.gwt\.gradle\.plugin:([\d.a-zA-Z-]+)/ },
+        replacement: { v, p -> "org.docstr.gwt:org.docstr.gwt.gradle.plugin:${v}" }
     ])
     pre("fileUpdate", [
         file       : "doc/latest/Overview.md",
@@ -51,8 +51,8 @@ scmVersion {
     ])
     pre("fileUpdate", [
         file       : "doc/latest/Overview.md",
-        pattern    : { v, p -> /org\.docstr\.gwt:gwt-gradle-plugin:([\d.a-zA-Z-]+)/ },
-        replacement: { v, p -> "org.docstr.gwt:gwt-gradle-plugin:${v}" }
+        pattern    : { v, p -> /org\.docstr\.gwt:org\.docstr\.gwt\.gradle\.plugin:([\d.a-zA-Z-]+)/ },
+        replacement: { v, p -> "org.docstr.gwt:org.docstr.gwt.gradle.plugin:${v}" }
     ])
     pre("fileUpdate", [
         file       : "doc/latest/Quickstart.md",

--- a/doc/latest/Overview.md
+++ b/doc/latest/Overview.md
@@ -48,7 +48,7 @@ plugins {
 gwt {
   // Optional: Set the GWT version, defaults to 2.12.1
   // gwtVersion = '2.12.1'
-  modules ['<YOUR-GWT-MODULE>']
+  modules = ['<YOUR-GWT-MODULE>']
 }
 ```
 
@@ -62,14 +62,14 @@ buildscript {
     }
   }
   dependencies {
-    classpath "org.docstr.gwt:gwt-gradle-plugin:2.2.4"
+    classpath "org.docstr.gwt:org.docstr.gwt.gradle.plugin:2.2.4"
   }
 }
 
 apply plugin: "org.docstr.gwt"
 
 gwt {
-    modules ['<YOUR-GWT-MODULE>']
+    modules = ['<YOUR-GWT-MODULE>']
 }
 ```
 

--- a/doc/latest/Quickstart.md
+++ b/doc/latest/Quickstart.md
@@ -39,7 +39,7 @@ the minimal configuration required to use the plugin:
 ```groovy
 gwt {
   // e.g. modules = ['com.example.MyModule']
-  modules['<YOUR-GWT-MODULE>']
+  modules = ['<YOUR-GWT-MODULE>']
 }
 ```
 


### PR DESCRIPTION
The README and Overview/Quickstart have problems with the way the modules are defined (missing '=') and also for the legacy method of applying the Gradle plugin.

For the second issue concerning the legacy method for applying the plugin, also note that https://plugins.gradle.org/plugin/org.docstr.gwt does have the correct info when expanding the "legacy method" section in the lower section of the page. I just happened to be using the instructions from the README here, which didn't work. I think they should better be in order.