### PR TITLE
Enable build caching for GwtCompileTask

### DIFF
--- a/plugin/src/main/java/org/docstr/gwt/GwtCompileTask.java
+++ b/plugin/src/main/java/org/docstr/gwt/GwtCompileTask.java
@@ -19,6 +19,7 @@ import javax.inject.Inject;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
@@ -27,6 +28,7 @@ import org.gradle.api.tasks.compile.JavaCompile;
 /**
  * Task for compiling GWT modules.
  */
+@CacheableTask
 public abstract class GwtCompileTask extends AbstractBaseTask {
 
   /**


### PR DESCRIPTION
## Summary
Enable build caching for GWT compilation tasks by adding the `@CacheableTask` annotation. This allows Gradle to cache and reuse compilation outputs when inputs haven't changed, significantly improving build performance.

- Adds `@CacheableTask` annotation to `GwtCompileTask`
- No changes to task behavior - only enables caching capability
- All required inputs and outputs were already properly annotated

## Impact
- **Performance improvement**: GWT compilation can be skipped when inputs haven't changed (saves up to 6 minutes per build as reported in #106)
- **Better developer experience**: Faster incremental builds when working on backend-only changes
- **CI optimization**: Cached outputs can be shared across builds and machines with remote cache